### PR TITLE
Add support for baking assets into binary

### DIFF
--- a/phi-server/Cargo.lock
+++ b/phi-server/Cargo.lock
@@ -590,6 +590,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482a2e29200b7eed25d7fdbd14423326760b7f6658d21a4cf12d55a50713c69f"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e074c19deab2501407c91ba1860fa3d6820bfde307db6d8cb851b55a10be89b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,7 +856,9 @@ dependencies = [
  "async-graphql-warp",
  "dotenv",
  "env_logger",
+ "include_dir",
  "log",
+ "mime_guess",
  "serde",
  "serde_json",
  "tokio",

--- a/phi-server/Cargo.toml
+++ b/phi-server/Cargo.toml
@@ -11,7 +11,9 @@ async-graphql = { version = "3.0.27", features = ["uuid"] }
 async-graphql-warp = "3.0.27"
 dotenv = "0.15"
 env_logger = "0.8"
+include_dir = { version = "0.7.2", optional = true }
 log = "0.4"
+mime_guess = { version = "2.0.3", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio-stream = { version = "0.1.8", features = ["sync"] }
@@ -21,3 +23,8 @@ warp = "0.3"
 [dependencies.tokio]
 version = "1"
 features = ["macros", "rt-multi-thread"]
+
+
+[features]
+default = []
+baked = ["include_dir", "mime_guess"]


### PR DESCRIPTION
With this new `baked` feature, the files in the `PHI_STATIC_DIR` are
recursively embedded into the binary, making for easier distribution.

As a follow-up to this, the Dockerfile has also been updated to use musl so that:

- the docker image is tiny (now around 13Mb, down from 96Mb)
- the binary can be copied out of the docker image for use on (any) Linux systems, without also requiring docker 