### PR TITLE
feat: configure server via cli/env

### DIFF
--- a/phi-server/Cargo.lock
+++ b/phi-server/Cargo.lock
@@ -22,6 +22,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ascii_utils"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +249,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,7 +292,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -497,6 +521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -861,6 +894,7 @@ dependencies = [
  "mime_guess",
  "serde",
  "serde_json",
+ "structopt",
  "tokio",
  "tokio-stream",
  "uuid",
@@ -913,6 +947,30 @@ checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
  "thiserror",
  "toml",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1130,9 +1188,39 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1166,6 +1254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1376,6 +1473,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1517,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/phi-server/Cargo.toml
+++ b/phi-server/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 mime_guess = { version = "2.0.3", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+structopt = "0.3.26"
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 warp = "0.3"

--- a/phi-server/src/cli.rs
+++ b/phi-server/src/cli.rs
@@ -1,0 +1,24 @@
+use crate::DeckType;
+use std::net::SocketAddr;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct Opt {
+    #[structopt(
+        long,
+        env = "PHI_ADMIN_KEY",
+        help = "The admin key unlocks special features in the UI when \
+        passed as the `key` url parameter. \
+        Defaults to a random value on startup when not specified."
+    )]
+    pub admin_key: Option<String>,
+    #[structopt(
+        long,
+        env = "PHI_DECK_TYPE",
+        default_value = "fib",
+        help = "Set the deck type: `fib` or `days`."
+    )]
+    pub deck_type: DeckType,
+    #[structopt(long, env = "PHI_HTTP_ADDR", default_value = "0.0.0.0:7878")]
+    pub http_addr: SocketAddr,
+}

--- a/phi-server/src/poker.rs
+++ b/phi-server/src/poker.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Mutex;
 use std::time::SystemTime;
 use tokio::sync::broadcast;
@@ -11,9 +12,22 @@ pub const FIB_DECK: [&str; 12] = [
 ];
 pub const DAYS_DECK: [&str; 9] = ["0.5", "1", "1.5", "2", "3", "5", "∞", "?", "☕"];
 
+#[derive(Debug)]
 pub enum DeckType {
     Fibonacci,
     Days,
+}
+
+impl FromStr for DeckType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "fib" | "" => Ok(DeckType::Fibonacci),
+            "days" => Ok(DeckType::Days),
+            _ => Err(format!("Invalid deck type: `{}`. Use `fib` or `days`.", s)),
+        }
+    }
 }
 
 /// Stable handle for identifying players, regardless of what the display name
@@ -21,7 +35,7 @@ pub enum DeckType {
 pub type PlayerId = Uuid;
 /// Certain features are only enabled for players who know the secret key for
 /// the session.
-pub type AdminKey = Uuid;
+pub type AdminKey = String;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Player {


### PR DESCRIPTION
Adds new CLI flags to configure:

- the bind address for the HTTP server
- the admin key (such that it can be something consistent rather than
  random)
- the deck type (formerly only configurable via env var)

An unfortunate inconsistency is in `PHI_STATIC_DIR` which remains only
configurable via env var (not included in the new set of CLI flags).

The reason for this is the asset baking happens at compile time and relies
on the same var, which also configures the location for SPA files on
disk in the non-baked mode.