### PR TITLE
Use cookies to track user identity, make player state more durable

### DIFF
--- a/phi-react/public/index.html
+++ b/phi-react/public/index.html
@@ -5,10 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Phi - Planning Poker"
-    />
+    <meta name="description" content="Phi - Planning Poker" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon.svg" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/phi-react/schema.graphql
+++ b/phi-react/schema.graphql
@@ -44,10 +44,10 @@ type Mutation {
   Clients that want admin privileges send their key.
   The bool return is for if the keys match or not.
   """
-  adminChallenge(key: UUID!): Boolean!
+  adminChallenge(key: String!): Boolean!
   heartbeat(playerId: UUID!): Boolean!
-  setPlayerName(playerId: UUID!, name: String!): Boolean!
-  setPlayerCard(playerId: UUID!, card: Int): Boolean!
+  setPlayerName(playerId: UUID!, name: String!): Player
+  setPlayerCard(playerId: UUID!, card: Int): Player
   removePlayer(playerId: UUID!): Boolean!
   call: Boolean!
   resume: Boolean!
@@ -62,6 +62,7 @@ type Player {
 
   """Index into the card data, `CARDS`."""
   selectedCard: Int
+  idle: Boolean!
 }
 
 type Query {

--- a/phi-react/src/App.tsx
+++ b/phi-react/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 import { PlayerCards } from './PlayerCards';
 import { CardPicker } from './CardPicker';
-import { gql, useMutation, useQuery, useSubscription } from '@apollo/client';
+import { gql, useMutation, useQuery } from '@apollo/client';
 import { GetCards } from './__generated__/GetCards';
 import { GetGameState } from './__generated__/GetGameState';
 import { GetClientId } from './__generated__/GetClientId';
@@ -32,7 +32,10 @@ const SEND_HEARTBEAT = gql`
 
 const SET_PLAYER_NAME = gql`
   mutation SetPlayerName($playerId: UUID!, $name: String!) {
-    setPlayerName(playerId: $playerId, name: $name)
+    setPlayerName(playerId: $playerId, name: $name) {
+      id
+      name
+    }
   }
 `;
 
@@ -43,13 +46,14 @@ const GET_CARDS = gql`
 `;
 
 const GET_GAME_STATE = gql`
-  subscription GetGameState {
+  query GetGameState {
     gameState {
       isCalling
       players {
         id
         selectedCard
         name
+        idle
       }
     }
   }
@@ -57,12 +61,15 @@ const GET_GAME_STATE = gql`
 
 const SET_PLAYER_CARD = gql`
   mutation SetPlayerCard($playerId: UUID!, $card: Int!) {
-    setPlayerCard(card: $card, playerId: $playerId)
+    setPlayerCard(card: $card, playerId: $playerId) {
+      id
+      selectedCard
+    }
   }
 `;
 
 const CHECK_ADMIN_KEY = gql`
-  mutation CheckAdminKey($key: UUID!) {
+  mutation CheckAdminKey($key: String!) {
     adminChallenge(key: $key)
   }
 `;
@@ -102,7 +109,9 @@ function App() {
 
   const isAdmin = !!adminChallengeData?.adminChallenge;
   const { data: cardData } = useQuery<GetCards>(GET_CARDS);
-  const { data: gameStateData } = useSubscription<GetGameState>(GET_GAME_STATE);
+  const { data: gameStateData } = useQuery<GetGameState>(GET_GAME_STATE, {
+    pollInterval: 750,
+  });
 
   const [getClientId, { data: registerData }] =
     useMutation<GetClientId>(REGISTER);
@@ -157,7 +166,7 @@ function App() {
         // reload the page to try and get a new one.
         window.location.reload();
       });
-    }, 3_000);
+    }, 8_000);
 
     return () => {
       window.clearTimeout(timer);

--- a/phi-react/src/App.tsx
+++ b/phi-react/src/App.tsx
@@ -196,6 +196,7 @@ function App() {
     <div className="container mx-auto flex flex-col space-y-4">
       <PlayerCards gameStateData={gameStateData} cards={cards} />
       <NameSetter
+        initialValue={player.name}
         onSubmit={(name) =>
           setPlayerName({
             variables: {

--- a/phi-react/src/NameSetter.tsx
+++ b/phi-react/src/NameSetter.tsx
@@ -1,6 +1,7 @@
 import React, { SyntheticEvent } from 'react';
 
 type Props = {
+  initialValue: string;
   onSubmit: (name: string) => void;
 };
 
@@ -14,7 +15,7 @@ export function NameSetter(props: Props) {
   return (
     <form onSubmit={handleSubmit}>
       <label>Name:</label>
-      <input name="playerName" />
+      <input name="playerName" defaultValue={props.initialValue} />
     </form>
   );
 }

--- a/phi-react/src/PlayerCards.tsx
+++ b/phi-react/src/PlayerCards.tsx
@@ -32,11 +32,14 @@ export function PlayerCards(props: Props) {
   }
 
   // Celebrate when everybody picks the same card.
+  const activePlayers = players.filter((p) => !p.idle);
   const consensus =
     isCalling &&
-    !!players.length &&
-    players[0].selectedCard !== null &&
-    players.every((p) => p.selectedCard === players[0].selectedCard);
+    !!activePlayers.length &&
+    activePlayers[0].selectedCard !== null &&
+    activePlayers.every(
+      (p) => p.selectedCard === activePlayers[0].selectedCard
+    );
 
   return (
     <div className={classes.join(' ')}>
@@ -53,7 +56,13 @@ export function PlayerCards(props: Props) {
                 {player.selectedCard !== null ? cards[player.selectedCard] : ''}
               </div>
             </div>
-            <div className={'name text-center'}>{player.name}</div>
+            <div
+              className={`name text-center ${
+                player.idle ? 'text-gray-400' : ''
+              }`}
+            >
+              {player.name}
+            </div>
           </div>
         );
       })}

--- a/phi-react/src/index.tsx
+++ b/phi-react/src/index.tsx
@@ -8,40 +8,40 @@ import {
   ApolloClient,
   InMemoryCache,
   HttpLink,
-  split,
+  // split,
 } from '@apollo/client';
-import { WebSocketLink } from '@apollo/client/link/ws';
-import { getMainDefinition } from '@apollo/client/utilities';
+// import { WebSocketLink } from '@apollo/client/link/ws';
+// import { getMainDefinition } from '@apollo/client/utilities';
 
 function getClient() {
   const httpLink = new HttpLink({
     uri: '/gql',
   });
 
-  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  // const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 
-  const wsLink = new WebSocketLink({
-    uri: `${proto}//${window.location.host}/gql`,
-    options: {
-      reconnect: true,
-    },
-  });
+  // const wsLink = new WebSocketLink({
+  //   uri: `${proto}//${window.location.host}/gql`,
+  //   options: {
+  //     reconnect: true,
+  //   },
+  // });
 
-  const splitLink = split(
-    ({ query }) => {
-      const definition = getMainDefinition(query);
-      return (
-        definition.kind === 'OperationDefinition' &&
-        definition.operation === 'subscription'
-      );
-    },
-    wsLink,
-    httpLink
-  );
+  // const splitLink = split(
+  //   ({ query }) => {
+  //     const definition = getMainDefinition(query);
+  //     return (
+  //       definition.kind === 'OperationDefinition' &&
+  //       definition.operation === 'subscription'
+  //     );
+  //   },
+  //   wsLink,
+  //   httpLink
+  // );
 
   return new ApolloClient({
     cache: new InMemoryCache(),
-    link: splitLink,
+    link: httpLink,
   });
 }
 

--- a/phi-react/src/setupProxy.js
+++ b/phi-react/src/setupProxy.js
@@ -5,7 +5,6 @@ module.exports = function (app) {
     '/gql',
     createProxyMiddleware({
       target: 'http://localhost:7878',
-      ws: true,
     })
   );
 };

--- a/phi-server/Cargo.lock
+++ b/phi-server/Cargo.lock
@@ -195,6 +195,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-session"
+version = "0.5.0-beta.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5562e924654d706f9fe3fe5a1644bb8ee311b58a1aa5d1451007efa35890975"
+dependencies = [
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "serde",
+ "serde_json",
+ "time",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +305,41 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
 
 [[package]]
 name = "ahash"
@@ -611,6 +663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,7 +707,14 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
+ "aes-gcm",
+ "base64",
+ "hkdf",
+ "hmac",
  "percent-encoding",
+ "rand",
+ "sha2",
+ "subtle",
  "time",
  "version_check",
 ]
@@ -697,6 +765,15 @@ checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array 0.14.5",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -764,6 +841,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -938,6 +1016,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+dependencies = [
+ "opaque-debug 0.3.0",
+ "polyval",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +1066,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1287,6 +1393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1484,7 @@ version = "0.1.0"
 dependencies = [
  "actix-files",
  "actix-rt",
+ "actix-session",
  "actix-web",
  "async-graphql",
  "async-graphql-actix-web",
@@ -1399,6 +1512,18 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "polyval"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1612,7 +1737,7 @@ dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -1620,6 +1745,17 @@ name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1704,6 +1840,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -1940,6 +2082,16 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "universal-hash"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+dependencies = [
+ "generic-array 0.14.5",
+ "subtle",
+]
 
 [[package]]
 name = "url"

--- a/phi-server/Cargo.toml
+++ b/phi-server/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 actix-files = "0.6.0-beta.16"
 actix-rt = "2.6.0"
+actix-session = "0.5.0-beta.8"
 actix-web = "4.0.0-rc.3"
 async-graphql = { version = "3.0.29", features = ["uuid"] }
 async-graphql-actix-web = "3.0.29"

--- a/phi-server/src/gql/mod.rs
+++ b/phi-server/src/gql/mod.rs
@@ -1,12 +1,83 @@
+use crate::poker::PlayerId;
+use actix_session::Session;
 use actix_web::{guard, web, HttpRequest, HttpResponse, Result};
 use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql::Schema;
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
+use std::sync::Arc;
 
 pub mod model;
 
-async fn index(schema: web::Data<model::PokerSchema>, req: GraphQLRequest) -> GraphQLResponse {
-    schema.execute(req.into_inner()).await.into()
+#[derive(Clone, Debug)]
+pub struct SessionIdentity {
+    name: String,
+    id: PlayerId,
+}
+
+pub fn get_session_identity(session: &Session) -> SessionIdentity {
+    let id: PlayerId = {
+        let sess_player_id = session.get::<PlayerId>("player_id").unwrap();
+        match sess_player_id {
+            None => {
+                let id = PlayerId::new_v4();
+                log::debug!("player id not in request, setting id={id}");
+                session.insert("player_id", id).unwrap();
+                id
+            }
+            Some(id) => {
+                log::trace!("player id in request: {}", &id);
+                id
+            }
+        }
+    };
+    let name: String = {
+        let sess_player_name = session.get::<String>("player_name").unwrap();
+        match sess_player_name {
+            None => {
+                let name = String::from("Guest");
+                log::debug!("player name not present in request, setting name={name}");
+                session.insert("player_name", name.clone()).unwrap();
+                name
+            }
+            Some(name) => {
+                log::trace!("player name in request: {}", &name);
+
+                name
+            }
+        }
+    };
+    SessionIdentity { id, name }
+}
+
+async fn index(
+    session: Session,
+    poker: web::Data<Arc<crate::poker::PlaySession>>,
+    schema: web::Data<model::PokerSchema>,
+    req: GraphQLRequest,
+) -> GraphQLResponse {
+    let req = req.into_inner();
+    let identity = get_session_identity(&session);
+    let req = req.data(identity.clone());
+    let resp = schema.execute(req).await.into();
+
+    {
+        let poker = poker.into_inner();
+        let gstate = poker.game_state.lock().unwrap();
+        if let Some(player) = gstate.players.get(&identity.id) {
+            if &player.name != &identity.name {
+                log::debug!(
+                    "Player name change detected: id={} old name={} new name={}",
+                    &identity.id,
+                    &identity.name,
+                    &player.name,
+                );
+                if let Err(e) = session.insert("player_name", &player.name) {
+                    log::error!("{e}");
+                }
+            }
+        }
+    }
+    resp
 }
 
 async fn index_ws(

--- a/phi-server/src/gql/model.rs
+++ b/phi-server/src/gql/model.rs
@@ -2,8 +2,10 @@
 //! design used for the websocket version, so I'm redefining a bunch of the
 //! types used for the game here.
 
+use crate::gql::SessionIdentity;
 use crate::poker::{AdminKey, PlayerId};
 use async_graphql::*;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio_stream::{self as stream, wrappers::BroadcastStream, Stream, StreamExt};
 
@@ -37,13 +39,13 @@ struct GameState;
 #[Object]
 impl GameState {
     async fn is_calling(&self, ctx: &Context<'_>) -> bool {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         let game_state = session.game_state.lock().unwrap();
         game_state.is_calling
     }
 
     async fn players(&self, ctx: &Context<'_>) -> Vec<Player> {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         let game_state = session.game_state.lock().unwrap();
         game_state.players.iter().map(Into::into).collect()
     }
@@ -54,7 +56,7 @@ pub struct Query;
 #[Object]
 impl Query {
     async fn cards(&self, ctx: &Context<'_>) -> &[&str] {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         session.deck
     }
 
@@ -68,27 +70,26 @@ pub struct Mutation;
 #[Object]
 impl Mutation {
     async fn register(&self, ctx: &Context<'_>) -> Result<PlayerId> {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
-        let player_id = PlayerId::new_v4();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
+        let SessionIdentity { name, id } = ctx.data_unchecked::<SessionIdentity>().clone();
+        let player = crate::poker::Player::new(name.clone(), id.clone());
         {
             let mut game_state = session.game_state.lock().unwrap();
-            game_state
-                .players
-                .insert(player_id, crate::poker::Player::new(String::from("Guest")));
+            game_state.players.insert(player.id, player);
         }
         session.notify_subscribers();
-        Ok(player_id)
+        Ok(id)
     }
 
     /// Clients that want admin privileges send their key.
     /// The bool return is for if the keys match or not.
     async fn admin_challenge(&self, ctx: &Context<'_>, key: AdminKey) -> Result<bool> {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         Ok(session.admin_key == key)
     }
 
     async fn heartbeat(&self, ctx: &Context<'_>, player_id: PlayerId) -> Result<bool> {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         {
             let mut state = session.game_state.lock().unwrap();
             if let Some(player) = state.players.get_mut(&player_id) {
@@ -121,7 +122,7 @@ impl Mutation {
         player_id: PlayerId,
         name: String,
     ) -> Result<bool> {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         let outcome = {
             let mut game_state = session.game_state.lock().unwrap();
             if let Some(player) = game_state.players.get_mut(&player_id) {
@@ -143,7 +144,7 @@ impl Mutation {
         card: Option<i32>,
     ) -> Result<bool> {
         let card = card.map(|n| n as usize);
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         let outcome = {
             let mut game_state = session.game_state.lock().unwrap();
             if game_state.is_calling {
@@ -167,7 +168,7 @@ impl Mutation {
     }
 
     async fn remove_player(&self, ctx: &Context<'_>, player_id: PlayerId) -> Result<bool> {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         {
             let mut game_state = session.game_state.lock().unwrap();
             game_state.players.remove(&player_id);
@@ -177,7 +178,7 @@ impl Mutation {
     }
 
     async fn call(&self, ctx: &Context<'_>) -> Result<bool> {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         {
             let mut game_state = session.game_state.lock().unwrap();
             game_state.is_calling = true;
@@ -187,7 +188,7 @@ impl Mutation {
     }
 
     async fn resume(&self, ctx: &Context<'_>) -> Result<bool> {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         {
             let mut game_state = session.game_state.lock().unwrap();
             game_state.is_calling = false;
@@ -197,7 +198,7 @@ impl Mutation {
     }
 
     async fn reset(&self, ctx: &Context<'_>) -> Result<bool> {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         {
             let mut game_state = session.game_state.lock().unwrap();
             for mut player in game_state.players.values_mut() {
@@ -219,7 +220,7 @@ pub struct Subscription;
 #[Subscription]
 impl Subscription {
     async fn game_state(&self, ctx: &Context<'_>) -> impl Stream<Item = GameState> {
-        let session = ctx.data_unchecked::<crate::poker::PlaySession>();
+        let session = ctx.data_unchecked::<Arc<crate::poker::PlaySession>>();
         let rx = BroadcastStream::new(session.game_state_notifier.subscribe());
         // Who knows when the next game state change will happen, so seed the
         // stream with one message to kick things off.

--- a/phi-server/src/poker.rs
+++ b/phi-server/src/poker.rs
@@ -39,6 +39,7 @@ pub type AdminKey = String;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Player {
+    pub id: PlayerId,
     /// The name displayed with the cards.
     pub name: String,
     /// Index into the card data, `CARDS`.
@@ -47,8 +48,9 @@ pub struct Player {
 }
 
 impl Player {
-    pub fn new(name: String) -> Player {
+    pub fn new(name: String, id: PlayerId) -> Player {
         Player {
+            id,
             name,
             selected_card: None,
             last_heartbeat: SystemTime::now(),


### PR DESCRIPTION
Fixes #6, #11 

Effectively this is all in an effort to make the app work better in cases where:

- the js VM might be suspended (meaning player heartbeats may not be sent)
- client connections might be "spotty" leaving local state inconsistent or possibly unable to update over websocket

By putting player IDs and names into a server-managed cookie, browser suspend/resume (in effect, tab reloads) should more cleanly resume where things left off. 

The threshold for heartbeats leading to a player being ejected from the game state has been extended to an hour, and a visual cue to the player card nametag has been added for players who fail to send a heartbeat before a 30-second deadline.

Finally, this PR switches away from using Websockets to propagate game state changes to all connected clients. The's a lot of code in the server left behind still in support of this, but it has proved too flaky for clients with weak connections. I'm leaving the code for WS in place for now, in the hopes that I can improve its reliability, but for now, polling seems the most pragmatic approach.

---

While the cookies mean refreshing the page has less of a penalty for the user (no longer needing to re-enter their name), I did notice that the code we fire on page unload to remove a player can disrupt a 2nd tab already open for the same session. The 2nd tab usually gets "stuck" with a loading message, requiring the player to reload manually. This is a situation we can probably improve with a little more work.